### PR TITLE
Copy Update

### DIFF
--- a/app/views/pages/timeline.html.erb
+++ b/app/views/pages/timeline.html.erb
@@ -21,35 +21,35 @@
     <ol class="relative border-l border-sky-500">                  
       <li class="mb-10 ml-4">
         <div class="absolute w-3 h-3 bg-sky-500 rounded-full mt-1.5 -left-1.5 border border-white"></div>
-        <time class="mb-1 text-sm font-normal leading-none text-slate-400" x-text="accelerated ? '2-3 Months' : '4-6 Months'"></time>
+        <time class="mb-1 text-sm font-normal leading-none text-slate-400" x-text="accelerated ? '~2-3 Months' : '~4-6 Months'"></time>
         <h3 class="text-lg font-semibold text-slate-900">Private Pilot Certificate</h3>
         <p class="mb-4 text-base font-normal text-slate-500">The first step in becoming a pilot is obtaining your private pilot certificate.  You'll learn how to fly a plane and at the end of this training, you will be able to take off and land by yourself and be the pilot in command (PIC) of an aircraft.</p>
         <%= link_to "EXPLORE PRIVATE PILOT", private_pilot_path, data: { turbo: false }, class: "btn-primary text-base" %>
       </li>
       <li class="mb-10 ml-4">
         <div class="absolute w-3 h-3 bg-sky-500 rounded-full mt-1.5 -left-1.5 border border-white"></div>
-        <time class="mb-1 text-sm font-normal leading-none text-slate-400" x-text="accelerated ? '2-3 Months' : '3-4 Months'"></time>
+        <time class="mb-1 text-sm font-normal leading-none text-slate-400" x-text="accelerated ? '~2-3 Months' : '~3-4 Months'"></time>
         <h3 class="text-lg font-semibold text-slate-900">Instrument Rating</h3>
         <p class="mb-4 text-base font-normal text-slate-500">After getting your private pilot certificate, the next step would be getting an instrument rating where you can fly without visual references.  Having an instrument rating allows you to fly in instrument meteorological conditions (IMC) and challenging weather.</p>
         <%= link_to "EXPLORE INSTRUMENT RATING", instrument_path, data: { turbo: false }, class: "btn-primary text-base" %>
       </li>
       <li class="mb-10 ml-4">
         <div class="absolute w-3 h-3 bg-sky-500 rounded-full mt-1.5 -left-1.5 border border-white"></div>
-        <time class="mb-1 text-sm font-normal leading-none text-slate-400" x-text="accelerated ? '2-3 Months' : '2-3 Months'"></time>
+        <time class="mb-1 text-sm font-normal leading-none text-slate-400" x-text="accelerated ? '~2-3 Months' : '~2-3 Months'"></time>
         <h3 class="text-lg font-semibold text-slate-900">Commercial Certificate</h3>
         <p class="mb-4 text-base font-normal text-slate-500">A major milestone in your pilot training.  Getting your commercial certificate allows you to fly for compensation or hire.  Many move on to becoming a CFI, but there are many other career options out there like surveying, charter, banner towing, and sky diving.</p>
         <%= link_to "EXPLORE COMMERCIAL PILOT", commercial_path, data: { turbo: false }, class: "btn-primary text-base" %>
       </li>
       <li class="mb-10 ml-4">
         <div class="absolute w-3 h-3 bg-sky-500 rounded-full mt-1.5 -left-1.5 border border-white"></div>
-        <time class="mb-1 text-sm font-normal leading-none text-slate-400" x-text="accelerated ? '2-3 Months' : '2-3 Months'"></time>
+        <time class="mb-1 text-sm font-normal leading-none text-slate-400" x-text="accelerated ? '~2-3 Months' : '~2-3 Months'"></time>
         <h3 class="text-lg font-semibold text-slate-900">Multi Engine Rating</h3>
         <p class="mb-4 text-base font-normal text-slate-500">Eventually, adding on a multi engine rating will be beneficial for your pilot career and make you more competitive.  With this rating, you can fly airplanes with multiple engines. This opens a whole new door of opportunity where you can fly more complex and advanced aircraft.</p>
         <%= link_to "EXPLORE MULTI ENGINE", multi_path, data: { turbo: false }, class: "btn-primary text-base" %>
       </li>
       <li class="mb-10 ml-4">
         <div class="absolute w-3 h-3 bg-sky-500 rounded-full mt-1.5 -left-1.5 border border-white"></div>
-        <time class="mb-1 text-sm font-normal leading-none text-slate-400" x-text="accelerated ? '2-3 Months' : '2-3 Months'"></time>
+        <time class="mb-1 text-sm font-normal leading-none text-slate-400" x-text="accelerated ? '~2-3 Months' : '~2-3 Months'"></time>
         <h3 class="text-lg font-semibold text-slate-900">Certified Flight Instructor</h3>
         <p class="mb-4 text-base font-normal text-slate-500">Touted as the best way to build time, become a CFI and help people new to aviation become pilots.  All while building the neccessary time needed to meet ATP minimums and airline requirements and then getting paid for it.</p>
         <%= link_to "EXPLORE CFI", cfi_path, data: { turbo: false }, class: "btn-primary text-base" %>
@@ -58,7 +58,7 @@
 
     <h4 class="font-semibold text-xl pb-10" 
       x-text="accelerated ? 
-      'Become a CFI within a year in our accelerated flight training program.  Build the necessary 1500 hours to qualify for ATP minimums and then become an airline pilot.' 
+      'Become a CFI in as little as one year in our accelerated flight training program. Build the necessary 1500 hours to qualify for ATP minimums and then become an airline pilot.' 
       : 
       'Become a CFI in as little as 18 months in our flexible flight training program.  Build the necessary 1500 hours to qualify for ATP minimums and then become an airline pilot.' ">
     </h4>


### PR DESCRIPTION
- [x] New Text: Become a CFI in as little as one year in our accelerated flight training program. Build the necessary 1500 hours to qualify for ATP minimums and then become an airline pilot.
- [x] Added a "~" before each month span on the timeline. Example: "~2-3 months"